### PR TITLE
feat: Upgrade project to .NET 10: SDK, runtime, Docker images and package updates

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "9.0.311",
+    "version": "10.0.101",
     "rollForward": "latestFeature"
   }
 }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "10.0.101",
+    "version": "10.0.201",
     "rollForward": "latestFeature"
   }
 }

--- a/src/GitHub.Release.Proxy/Dockerfile
+++ b/src/GitHub.Release.Proxy/Dockerfile
@@ -1,6 +1,6 @@
 ARG BUILDPLATFORM=linux/amd64
 
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:9.0-alpine3.21@sha256:28bd5605c0592f5bba90670ccd9af1af2c41c9fb0fbe4e666106791c94d8b60f AS build
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:10.0-alpine AS build
 RUN apk add build-base zlib-dev
 WORKDIR /src
 COPY GitHub.Release.Proxy.csproj .
@@ -12,34 +12,34 @@ FROM build AS publish
 ARG VERSION=0.0.1
 RUN dotnet publish "GitHub.Release.Proxy.csproj" -c Release --use-current-runtime -o /app/publish /p:Version=${VERSION}
 
-FROM mcr.microsoft.com/dotnet/runtime-deps:9.0-alpine3.21@sha256:819bb62452393a158d6aa41178127889b45690dc90bb5823c241776ac2610229 AS base
+FROM mcr.microsoft.com/dotnet/runtime-deps:10.0-alpine AS base
 WORKDIR /app
 EXPOSE 8080
 
 LABEL org.opencontainers.image.description="Simple Github Release Proxy"
 
-# renovate: datasource=repology depName=alpine_3_21/ca-certificates-bundle versioning=loose
+# renovate: datasource=repology depName=alpine_3_23/ca-certificates-bundle versioning=loose
 ENV CA_CERTIFICATES_BUNDLES_VERSION="20250911-r0"
 
-# renovate: datasource=repology depName=alpine_3_21/busybox versioning=loose
+# renovate: datasource=repology depName=alpine_3_23/busybox versioning=loose
 ENV BUSYBOX_VERSION="1.37.0-r14"
 
-# renovate: datasource=repology depName=alpine_3_21/busybox-binsh versioning=loose
+# renovate: datasource=repology depName=alpine_3_23/busybox-binsh versioning=loose
 ENV BUSYBOX_BINSH_VERSION="1.37.0-r14"
 
-# renovate: datasource=repology depName=alpine_3_21/libcrypto3 versioning=loose
+# renovate: datasource=repology depName=alpine_3_23/libcrypto3 versioning=loose
 ENV LIBCRYPTO3_VERSION="3.3.6-r0"
 
-# renovate: datasource=repology depName=alpine_3_21/ssl_client versioning=loose
+# renovate: datasource=repology depName=alpine_3_23/ssl_client versioning=loose
 ENV SSL_VERSION="1.37.0-r14"
 
-# renovate: datasource=repology depName=alpine_3_21/libgcc versioning=loose
+# renovate: datasource=repology depName=alpine_3_23/libgcc versioning=loose
 ENV LIBGCC_VERSION="14.2.0-r4"
 
-# renovate: datasource=repology depName=alpine_3_21/libssl3 versioning=loose
+# renovate: datasource=repology depName=alpine_3_23/libssl3 versioning=loose
 ENV LIBSSL3_VERSION="3.3.6-r0"
 
-# renovate: datasource=repology depName=alpine_3_21/libstdc++ versioning=loose
+# renovate: datasource=repology depName=alpine_3_23/libstdc++ versioning=loose
 ENV LIBSTDC_VERSION="14.2.0-r4"
 
 RUN apk add --upgrade --no-cache \

--- a/src/GitHub.Release.Proxy/GitHub.Release.Proxy.csproj
+++ b/src/GitHub.Release.Proxy/GitHub.Release.Proxy.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <EnableConfigurationBindingGenerator>true</EnableConfigurationBindingGenerator>
     <EnableRequestDelegateGenerator>true</EnableRequestDelegateGenerator>
     <ImplicitUsings>enable</ImplicitUsings>
@@ -23,8 +23,8 @@
 
   <ItemGroup>
     <PackageReference Include="FluentValidation" Version="12.1.1" />
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.13" />
-    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="9.10.0" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.0.0" />
     <PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.15.0-beta.1" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.0" />


### PR DESCRIPTION
### Motivation

- Move the project to .NET 10 to adopt the new SDK/runtime and language/runtime improvements.
- Ensure the Docker build and runtime images match the new SDK and runtime versions for consistency.
- Update dependent package versions to be compatible with the .NET 10 target framework.

### Description

- Bumped the SDK in `global.json` to `10.0.101`.
- Switched the Docker build base to `mcr.microsoft.com/dotnet/sdk:10.0-alpine` and the runtime base to `mcr.microsoft.com/dotnet/runtime-deps:10.0-alpine` and updated renovate datasource lines from `alpine_3_21` to `alpine_3_23` in `src/GitHub.Release.Proxy/Dockerfile`.
- Updated `GitHub.Release.Proxy.csproj` to target `net10.0` and upgraded `Microsoft.AspNetCore.OpenApi` and `Microsoft.Extensions.Http.Resilience` package references to `10.0.0` while keeping other project properties and settings unchanged.

### Testing

- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b630d2316883269a667413633cb82c)