### PR TITLE
fix: Upgrade to .NET 10.0 and update Docker base images and package versions

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "9.0.311",
+    "version": "10.0.201",
     "rollForward": "latestFeature"
   }
 }

--- a/src/GitHub.Release.Proxy/Dockerfile
+++ b/src/GitHub.Release.Proxy/Dockerfile
@@ -1,6 +1,6 @@
 ARG BUILDPLATFORM=linux/amd64
 
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:9.0-alpine3.21@sha256:28bd5605c0592f5bba90670ccd9af1af2c41c9fb0fbe4e666106791c94d8b60f AS build
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:10.0-alpine@sha256:2b0e46d490f5b53a8dc07fbf636cdf5b90796878a256e1ce5b441e8d9675c5f4 AS build
 RUN apk add build-base zlib-dev
 WORKDIR /src
 COPY GitHub.Release.Proxy.csproj .
@@ -12,34 +12,34 @@ FROM build AS publish
 ARG VERSION=0.0.1
 RUN dotnet publish "GitHub.Release.Proxy.csproj" -c Release --use-current-runtime -o /app/publish /p:Version=${VERSION}
 
-FROM mcr.microsoft.com/dotnet/runtime-deps:9.0-alpine3.21@sha256:819bb62452393a158d6aa41178127889b45690dc90bb5823c241776ac2610229 AS base
+FROM mcr.microsoft.com/dotnet/runtime-deps:10.0-alpine@sha256:122e6638ff460ba7c7455a9dd1b81332b6e17f9845620229ca3e3b26947d4c07 AS base
 WORKDIR /app
 EXPOSE 8080
 
 LABEL org.opencontainers.image.description="Simple Github Release Proxy"
 
-# renovate: datasource=repology depName=alpine_3_21/ca-certificates-bundle versioning=loose
+# renovate: datasource=repology depName=alpine_3_23/ca-certificates-bundle versioning=loose
 ENV CA_CERTIFICATES_BUNDLES_VERSION="20250911-r0"
 
-# renovate: datasource=repology depName=alpine_3_21/busybox versioning=loose
+# renovate: datasource=repology depName=alpine_3_23/busybox versioning=loose
 ENV BUSYBOX_VERSION="1.37.0-r14"
 
-# renovate: datasource=repology depName=alpine_3_21/busybox-binsh versioning=loose
+# renovate: datasource=repology depName=alpine_3_23/busybox-binsh versioning=loose
 ENV BUSYBOX_BINSH_VERSION="1.37.0-r14"
 
-# renovate: datasource=repology depName=alpine_3_21/libcrypto3 versioning=loose
+# renovate: datasource=repology depName=alpine_3_23/libcrypto3 versioning=loose
 ENV LIBCRYPTO3_VERSION="3.3.6-r0"
 
-# renovate: datasource=repology depName=alpine_3_21/ssl_client versioning=loose
+# renovate: datasource=repology depName=alpine_3_23/ssl_client versioning=loose
 ENV SSL_VERSION="1.37.0-r14"
 
-# renovate: datasource=repology depName=alpine_3_21/libgcc versioning=loose
+# renovate: datasource=repology depName=alpine_3_23/libgcc versioning=loose
 ENV LIBGCC_VERSION="14.2.0-r4"
 
-# renovate: datasource=repology depName=alpine_3_21/libssl3 versioning=loose
+# renovate: datasource=repology depName=alpine_3_23/libssl3 versioning=loose
 ENV LIBSSL3_VERSION="3.3.6-r0"
 
-# renovate: datasource=repology depName=alpine_3_21/libstdc++ versioning=loose
+# renovate: datasource=repology depName=alpine_3_23/libstdc++ versioning=loose
 ENV LIBSTDC_VERSION="14.2.0-r4"
 
 RUN apk add --upgrade --no-cache \

--- a/src/GitHub.Release.Proxy/GitHub.Release.Proxy.csproj
+++ b/src/GitHub.Release.Proxy/GitHub.Release.Proxy.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <EnableConfigurationBindingGenerator>true</EnableConfigurationBindingGenerator>
     <EnableRequestDelegateGenerator>true</EnableRequestDelegateGenerator>
     <ImplicitUsings>enable</ImplicitUsings>
@@ -23,8 +23,8 @@
 
   <ItemGroup>
     <PackageReference Include="FluentValidation" Version="12.1.1" />
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.13" />
-    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="9.10.0" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.0.0" />
     <PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.15.0-beta.1" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.0" />


### PR DESCRIPTION
### Motivation
- Move the solution forward to .NET 10 to pick up runtime, SDK, and package updates required for next-generation features and security updates.
- Align Docker images and Alpine package references with the newer .NET 10 runtime images and updated OS package set.

### Description
- Bumped the global SDK version in `global.json` from `9.0.311` to `10.0.201`.
- Updated the `Dockerfile` to use the `.NET 10` SDK and runtime-deps images and adjusted renovate datasource comments from `alpine_3_21` to `alpine_3_23` while keeping/updating Alpine package version variables.
- Changed the project target framework in `src/GitHub.Release.Proxy/GitHub.Release.Proxy.csproj` from `net9.0` to `net10.0`.
- Upgraded package references for `Microsoft.AspNetCore.OpenApi` and `Microsoft.Extensions.Http.Resilience` to `10.0.0` and left other package versions as-is.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b630d2316883269a667413633cb82c)